### PR TITLE
Use html as the default output format

### DIFF
--- a/src/tmt_web/api.py
+++ b/src/tmt_web/api.py
@@ -289,7 +289,7 @@ def root(
             alias="format",
             description="Output format for the response",
         ),
-    ] = "json",
+    ] = "html",
 ) -> TaskOut | HTMLResponse | JSONResponse | PlainTextResponse | RedirectResponse:
     """Process a request for test, plan, or both.
 
@@ -388,7 +388,7 @@ def get_task_status_html(
     if r.successful() and r.result:
         # For successful tasks, redirect to root endpoint
         return RedirectResponse(
-            url=f"{settings.API_HOSTNAME}/?task-id={r.task_id}&format=html",
+            url=f"{settings.API_HOSTNAME}/?task-id={r.task_id}",
             status_code=303,  # Use 303 See Other for GET redirects
         )
 


### PR DESCRIPTION
Trivial change to implement #13.

I'd use this PR to do a bit more refactoring in this area. Namely, when a new request is submitted, the user follows this flow of endpoints:
1. http://localhost:8000/?plan-url=https://gitlab.com/testing-farm/tests&plan-name=/testing-farm/sanity
2. http://localhost:8000/status/html?task-id=3ff31433-5f94-49e8-90e8-cd6f3f0c40a0
3. http://localhost:8000/?task-id=3ff31433-5f94-49e8-90e8-cd6f3f0c40a0

I find step 2. unnecessary (endpoints `/status` and `/status/html`) so I'd ideally remove them and present outputs in `/` endpoint. It creates inconsistencies when requesting for a different output format, where user follows these endpoints:
1. http://localhost:8000/?plan-url=https://gitlab.com/testing-farm/tests&plan-name=/testing-farm/sanity&format=json
2. http://localhost:8000/status?task-id=054fb9d2-9ae1-407b-9ebb-ba25e63bc245

When `format=json` is used, the result is shown in `/status` endpoint. `/status` endpoint implements an another inconsistency regarding format specification. While `/` endpoint specifies format via the `format=foo` query parameter, `/status` has it built in its path (`/status` for `json`, `/status/html` for `html`).