### PR TITLE
Fix handling of '.' as tree_path in get_tree function

### DIFF
--- a/src/tmt_web/service.py
+++ b/src/tmt_web/service.py
@@ -42,7 +42,11 @@ def get_tree(url: str, name: str, ref: str | None, tree_path: str | None) -> tmt
     except Exception as exc:
         raise GeneralError(f"Failed to clone repository: {exc}") from exc
 
-    if tree_path is not None:
+    if tree_path == ".":
+        # Handle current directory case - no path modification needed
+        if path.suffix == ".git":
+            path = path.with_suffix("")
+    elif tree_path is not None:
         tree_path += "/"
         # If path is set, construct a path to the tmt Tree
         if path.suffix == ".git":

--- a/tests/unit/test_service.py
+++ b/tests/unit/test_service.py
@@ -100,6 +100,38 @@ def test_get_tree_with_git_suffix(mocker):
     mock_path.with_suffix.assert_called_once_with("")
 
 
+def test_get_tree_with_dot_path(mocker):
+    """Test get_tree with '.' as tree_path (current directory)."""
+    mock_path = mocker.Mock()
+    mock_path.suffix = ""
+    mock_path.with_suffix.return_value = mock_path
+    mock_path.as_posix.return_value = "/path/to/repo"
+    mocker.patch("tmt_web.utils.git_handler.get_git_repository", return_value=mock_path)
+    mocker.patch("tmt.base.Tree")
+    mocker.patch("tmt.plugins.explore")
+
+    get_tree("url", "test", None, ".")
+    # Should not call as_posix() when tree_path is "."
+    mock_path.as_posix.assert_not_called()
+
+
+def test_get_tree_with_dot_path_and_git_suffix(mocker):
+    """Test get_tree with '.' as tree_path and .git suffix."""
+    mock_path = mocker.Mock()
+    mock_path.suffix = ".git"
+    mock_path.with_suffix.return_value = mock_path
+    mock_path.as_posix.return_value = "/path/to/repo"
+    mocker.patch("tmt_web.utils.git_handler.get_git_repository", return_value=mock_path)
+    mocker.patch("tmt.base.Tree")
+    mocker.patch("tmt.plugins.explore")
+
+    get_tree("url", "test", None, ".")
+    # Should still strip .git suffix when tree_path is "."
+    mock_path.with_suffix.assert_called_once_with("")
+    # Should not call as_posix() when tree_path is "."
+    mock_path.as_posix.assert_not_called()
+
+
 def test_format_data_unsupported_format(mocker, logger):
     """Test format_data with unsupported format."""
     test_data = TestData(name="test")


### PR DESCRIPTION
When tree_path is '.', the current code constructs invalid paths like '/path/to/repo./' which causes "Invalid directory path" errors.

This fix adds special handling for '.' (current directory) to avoid path modification while still handling .git suffix removal properly.

Fixes #19

🤖 Generated with [Claude Code](https://claude.ai/code)