### PR TITLE
Update tmt package version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
   "Operating System :: POSIX :: Linux",
 ]
 dependencies = [
-  "tmt~=1.36",
+  "tmt~=1.65",
   "fastapi~=0.115",
   "httpx~=0.27",
   "uvicorn~=0.30",

--- a/src/tmt_web/formatters.py
+++ b/src/tmt_web/formatters.py
@@ -3,7 +3,7 @@
 import json
 
 from tmt import Logger
-from tmt.utils import dict_to_yaml
+from tmt.utils import to_yaml
 
 from tmt_web.generators import html_generator
 from tmt_web.models import PlanData, TestData, TestPlanData
@@ -20,7 +20,7 @@ def _format_yaml(data: TestData | PlanData | TestPlanData) -> str:
     data_dict = data.model_dump(by_alias=True)
     # Then use tmt's yaml formatter
 
-    return dict_to_yaml(data_dict)
+    return to_yaml(data_dict)
 
 
 def _format_html(data: TestData | PlanData | TestPlanData, logger: Logger) -> str:

--- a/src/tmt_web/generators/yaml_generator.py
+++ b/src/tmt_web/generators/yaml_generator.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from tmt import Logger, Plan, Test
-from tmt.utils import GeneralError, dict_to_yaml
+from tmt.utils import GeneralError, to_yaml
 
 from tmt_web.generators.json_generator import CombinedTestPlanModel, ObjectModel
 
@@ -17,7 +17,7 @@ def _serialize_yaml(data: dict[str, Any], logger: Logger) -> str:
     """
     try:
         logger.debug("Serializing data to YAML")
-        return dict_to_yaml(data)
+        return to_yaml(data)
     except Exception as err:
         logger.fail("Failed to serialize data to YAML")
         raise GeneralError("Failed to generate YAML output") from err

--- a/tests/unit/test_yaml_generator.py
+++ b/tests/unit/test_yaml_generator.py
@@ -78,10 +78,10 @@ class TestYamlGenerator:
     def test_yaml_serialization_error(self, test_obj, logger, monkeypatch):
         """Test error handling when YAML serialization fails."""
 
-        def mock_dict_to_yaml(*args, **kwargs):
+        def mock_to_yaml(*args, **kwargs):
             raise ValueError("YAML serialization failed")
 
-        monkeypatch.setattr(yaml_generator, "dict_to_yaml", mock_dict_to_yaml)
+        monkeypatch.setattr(yaml_generator, "to_yaml", mock_to_yaml)
 
         with pytest.raises(GeneralError) as exc:
             yaml_generator.generate_test_yaml(test_obj, logger)


### PR DESCRIPTION
Since tmt-1.65, the `tmt.utils.dict_to_yaml` function was renamed to `to_yaml`. This PR bumps the minimum required tmt version from `~=1.36` to `~=1.65` and updates all call sites to use the new name.